### PR TITLE
Remove ow2 for breach of foundation-neutrality.

### DIFF
--- a/handbook-map-EN.md
+++ b/handbook-map-EN.md
@@ -10,7 +10,6 @@ markmap:
 - [GGI Handbook Mindmap](https://github.com/bayoss/GGI-handbook-mindmap)
 - [GGI Handbook ](https://ospo-alliance.org/ggi/)
 - [OSPO Alliance](https://ospo-alliance.org/)
-- [OW2](https://www.ow2.org/)
 
 ## Introduction
 

--- a/handbook-map-ZH.md
+++ b/handbook-map-ZH.md
@@ -10,7 +10,6 @@ markmap:
 - [GGI Handbook Mindmap](https://github.com/bayoss/GGI-handbook-mindmap)
 - [GGI Handbook ](https://ospo-alliance.org/ggi/)
 - [OSPO Alliance](https://ospo-alliance.org/)
-- [OW2](https://www.ow2.org/)
 
 ## 概述
 


### PR DESCRIPTION
Hiho, 

First things first: thank you for this contribution! It looks great, it's right  to-the-point, we highly appreciate it.

As mentioned elsewhere, the OSPO Alliance strives to be vendor- and foundation- neutral, so we'd need to remove the direct link to OW2 before using it. Please consider this humble change to allow us to reuse it. And let me know if you have any question.

Have a wonderful day!